### PR TITLE
Implement RocksDB storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,16 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,12 +1435,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "networking 0.1.0",
  "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tezos_encoding 0.1.0",
 ]
 
@@ -1922,7 +1911,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bitvec 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfadef5c4e2c2e64067b9ecc061179f12ac7ec65ba613b1f60f3972bbada1f5b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,6 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "networking 0.1.0",
  "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tezos_encoding 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +159,17 @@ dependencies = [
 name = "cc"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -152,6 +185,16 @@ dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -283,6 +326,23 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "env_logger"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -419,6 +479,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "h2"
 version = "0.2.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,6 +549,14 @@ dependencies = [
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hyper"
@@ -562,6 +643,26 @@ dependencies = [
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libloading"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,6 +914,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "pin-project"
 version = "0.4.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +961,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -993,6 +1104,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1254,15 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rocksdb"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "librocksdb-sys 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1380,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1434,7 @@ name = "storage"
 version = "0.1.0"
 dependencies = [
  "networking 0.1.0",
+ "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tezos_encoding 0.1.0",
 ]
 
@@ -1348,6 +1496,14 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1656,6 +1812,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,9 +1845,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ws2_32-sys"
@@ -1724,14 +1906,17 @@ dependencies = [
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bitvec 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfadef5c4e2c2e64067b9ecc061179f12ac7ec65ba613b1f60f3972bbada1f5b"
 "checksum blake2b_simd 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bf775a81bb2d464e20ff170ac20316c7b08a43d11dbc72f0f82e8e8d3d6d0499"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
+"checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+"checksum clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
@@ -1744,6 +1929,8 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
@@ -1759,12 +1946,15 @@ dependencies = [
 "checksum futures-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)" = "efa8f90c4fb2328e381f8adfd4255b4a2b696f77d1c63a3dee6700b564c4e4b5"
 "checksum futures-sink-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)" = "e9b65a2481863d1b78e094a07e9c0eed458cc7dc6e72b22b7138b8a67d924859"
 "checksum futures-util-preview 0.3.0-alpha.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7df53daff1e98cc024bf2720f3ceb0414d96fbb0a94f3cad3a5c3bf3be1d261c"
+"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum h2 0.2.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6000ed6220e54986be8e0a647fddaee205559e5cbea0ac36205b005414b92fdb"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum honggfuzz 0.5.45 (registry+https://github.com/rust-lang/crates.io-index)" = "24c27b4aa3049d6d10d8e33d52c9d03ca9aec18f8a449b246f8c4a5b0c10fb34"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.2.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1bc8dfa1f6155eadd665d39458a6c1a2c37bbd372a053383a4245775a0d9d98a"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+"checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum hyper 0.13.0-alpha.1 (git+https://github.com/hyperium/hyper.git)" = "<none>"
 "checksum indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4d6d89e0948bf10c08b9ecc8ac5b83f07f857ebe2c0cbe38de15b4e4f510356"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -1774,6 +1964,8 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
+"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+"checksum librocksdb-sys 6.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6af56e6599bce586321e8ba8acf8a0a5e97431fd9ab49f9b69f92d93fe642c6"
 "checksum libsodium-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "adecedd56966d117ef65b2d03aab14f1b56da9c8054a8e09bee5201c9937867e"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
@@ -1796,12 +1988,14 @@ dependencies = [
 "checksum ocaml 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b35420d9f5a62a47de8a3fad5b2177b8775e6fa5f1dc5c567089e411a8041c08"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum pin-project 0.4.0-alpha.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5735db2fbc10ccb05c20f6abb5c016a946ab5cc82f315419ecf6f3710f51e005"
 "checksum pin-project-internal 0.4.0-alpha.9 (registry+https://github.com/rust-lang/crates.io-index)" = "100f383f50075704e4dc89247125f341140eb530ca9614b65c80e933934134bb"
 "checksum pin-utils 0.1.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -1816,6 +2010,8 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
+"checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
@@ -1829,6 +2025,7 @@ dependencies = [
 "checksum riker-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f06e98f4eb1a65f85e01c38a42f2b6823968f8257e35ff5bb4ae1dc996f4fd09"
 "checksum riker-patterns 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1443c41d24a37ef2e23d6add715786b22e38286ae61a7df9d135c2c62b892264"
 "checksum rle-decode-fast 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+"checksum rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e7523c32e26bf2ebc4540645961dafcbd086c652e8ecb563a507f432eb7636d"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
@@ -1843,6 +2040,7 @@ dependencies = [
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+"checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum signal-hook-registry 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1797d48f38f91643908bb14e35e79928f9f4b3cefb2420a564dde0991b4358dc"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
@@ -1856,6 +2054,7 @@ dependencies = [
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -1885,11 +2084,14 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "networking 0.1.0",
  "riker 0.3.2 (git+https://github.com/riker-rs/riker)",
+ "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell 0.1.0",
@@ -1375,6 +1376,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "networking 0.1.0",
  "riker 0.3.2 (git+https://github.com/riker-rs/riker)",
+ "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage 0.1.0",
  "tezos_encoding 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.49.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +237,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hjson 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -693,7 +703,7 @@ dependencies = [
  "networking 0.1.0",
  "riker 0.3.2 (git+https://github.com/riker-rs/riker)",
  "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "shell 0.1.0",
  "storage 0.1.0",
@@ -820,7 +830,7 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "riker 0.3.2 (git+https://github.com/riker-rs/riker)",
  "riker-patterns 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tezos_encoding 0.1.0",
  "tokio 0.2.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +859,7 @@ dependencies = [
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1321,7 +1331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1356,7 +1366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1423,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1435,9 +1445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
+ "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "networking 0.1.0",
  "rocksdb 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "tezos_encoding 0.1.0",
 ]
 
@@ -1531,7 +1544,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1704,7 +1717,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1909,6 +1922,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base58 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
 "checksum bindgen 0.49.2 (registry+https://github.com/rust-lang/crates.io-index)" = "846a1fba6535362a01487ef6b10f0275faa12e5c5d835c5c1c627aabc46ccbd6"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum bitvec 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfadef5c4e2c2e64067b9ecc061179f12ac7ec65ba613b1f60f3972bbada1f5b"
@@ -2038,7 +2052,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
+"checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde-hjson 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b833c5ad67d52ced5f5938b2980f32a9c1c5ef047f0b4fb3127e7a423c76153"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2019 SimpleStaking and Tezos-RS Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ opam update
 opam install dune
 ```
 
+Install libs required to build RocksDB package:
+```
+sudo apt install clang libclang-dev llvm llvm-dev linux-kernel-headers
+```
 
 Building
 --------

--- a/light_node/.gitignore
+++ b/light_node/.gitignore
@@ -1,2 +1,3 @@
 # Log files
 /logs
+/bootstrap_db/

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -15,7 +15,7 @@ lazy_static = "1.3.0"
 log = "0.4.8"
 riker = { git = "https://github.com/riker-rs/riker" }
 rocksdb = "0.12.3"
-serde = { version = "1.0.99", features = ["derive"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
 tokio = { version = "0.2.0-alpha.4", features = ["signal"] }
 # Local dependencies

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -14,6 +14,7 @@ hex = "0.3.2"
 lazy_static = "1.3.0"
 log = "0.4.8"
 riker = { git = "https://github.com/riker-rs/riker" }
+rocksdb = "0.12.3"
 serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0.40"
 tokio = { version = "0.2.0-alpha.4", features = ["signal"] }

--- a/light_node/src/configuration/mod.rs
+++ b/light_node/src/configuration/mod.rs
@@ -27,6 +27,7 @@ pub struct Environment {
     pub initial_peers: Vec<SocketAddr>,
     pub identity_json_file_path: Option<PathBuf>,
     pub log_message_contents: bool,
+    pub bootstrap_db_path: PathBuf,
 }
 
 impl Environment {
@@ -70,6 +71,12 @@ impl Environment {
                 .takes_value(true)
                 .default_value("true")
                 .help("Log message contents. Default: true"))
+            .arg(Arg::with_name("bootstrap-db-path")
+                .short("B")
+                .long("bootstrap-db-path")
+                .takes_value(true)
+                .default_value("bootstrap_db")
+                .help("Path to bootstrap database directory. Default: bootstrap_db"))
             .get_matches();
 
         Environment {
@@ -107,6 +114,10 @@ impl Environment {
                 .unwrap()
                 .parse::<bool>()
                 .expect("Was expecting value of log-message-contents"),
+            bootstrap_db_path: args.value_of("bootstrap-db-path")
+                .unwrap_or_default()
+                .parse::<PathBuf>()
+                .expect("Provided value cannot be converted to path")
         }
     }
 }

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
         network_manager.clone(),
         &configuration::ENV.p2p.bootstrap_lookup_addresses,
         &configuration::ENV.initial_peers,
-        Threshold::new(15, 30))
+        Threshold::new(2, 30))
         .expect("Failed to create peer manager");
     let _ = ChainManager::actor(&actor_system, network_channel.clone(), Arc::new(rocks_db));
 

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use log::{error, info};
 use riker::actors::*;
@@ -11,9 +12,9 @@ use networking::p2p::network_channel::NetworkChannel;
 use networking::p2p::network_manager::NetworkManager;
 use shell::chain_manager::ChainManager;
 use shell::peer_manager::{PeerManager, Threshold};
-use storage::persistent::{open_db, Schema};
 use storage::block_storage::BlockStorage;
-use std::sync::Arc;
+use storage::operations_storage::{OperationsMetaStorage, OperationsStorage};
+use storage::persistent::{open_db, Schema};
 
 mod configuration;
 
@@ -40,7 +41,9 @@ fn main() {
     let identity = identity.unwrap();
 
     let schemas = vec![
-        BlockStorage::cf_descriptor()
+        BlockStorage::cf_descriptor(),
+        OperationsStorage::cf_descriptor(),
+        OperationsMetaStorage::cf_descriptor(),
     ];
     let rocks_db = open_db(&configuration::ENV.bootstrap_db_path, schemas)
         .expect(&format!("Failed to create RocksDB database at '{:?}'", &configuration::ENV.bootstrap_db_path));

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         network_manager.clone(),
         &configuration::ENV.p2p.bootstrap_lookup_addresses,
         &configuration::ENV.initial_peers,
-        Threshold::new(2, 30))
+        Threshold::new(15, 30))
         .expect("Failed to create peer manager");
     let _ = ChainManager::actor(&actor_system, network_channel.clone());
 

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -40,9 +40,9 @@ fn main() {
     let identity = identity.unwrap();
 
     let schemas = vec![
-        <BlockStorage as Schema>::COLUMN_FAMILY_NAME
+        BlockStorage::cf_descriptor()
     ];
-    let rocks_db = open_db(&configuration::ENV.bootstrap_db_path, &schemas)
+    let rocks_db = open_db(&configuration::ENV.bootstrap_db_path, schemas)
         .expect(&format!("Failed to create RocksDB database at '{:?}'", &configuration::ENV.bootstrap_db_path));
 
     let actor_system = ActorSystem::new().expect("Failed to create actor system");

--- a/networking/Cargo.toml
+++ b/networking/Cargo.toml
@@ -19,7 +19,7 @@ num-bigint = "0.2.2"
 num-traits = "0.2.8"
 riker = { git = "https://github.com/riker-rs/riker" }
 riker-patterns = "0.3.2"
-serde = { version = "1.0.99", features = ["derive"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
 tokio = "0.2.0-alpha.4"
 # local dependencies

--- a/networking/src/p2p/encoding/block_header.rs
+++ b/networking/src/p2p/encoding/block_header.rs
@@ -34,7 +34,7 @@ impl HasEncoding for GetBlockHeadersMessage {
 }
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct BlockHeader {
     pub level: i32,
     pub proto: u8,

--- a/networking/src/p2p/encoding/operation.rs
+++ b/networking/src/p2p/encoding/operation.rs
@@ -20,7 +20,7 @@ impl HasEncoding for OperationMessage {
 
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct Operation {
     branch: BlockHash,
     data: Vec<u8>,

--- a/networking/src/p2p/encoding/operations_for_blocks.rs
+++ b/networking/src/p2p/encoding/operations_for_blocks.rs
@@ -7,7 +7,7 @@ use tezos_encoding::hash::{BlockHash, HashEncoding, HashType, Hash};
 use crate::p2p::encoding::operation::Operation;
 use std::rc::Rc;
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct OperationsForBlock {
     pub hash: BlockHash,
     pub validation_pass: i8
@@ -23,7 +23,7 @@ impl HasEncoding for OperationsForBlock {
 }
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct OperationsForBlocksMessage {
     pub operations_for_block: OperationsForBlock,
     pub operation_hashes_path: Path,
@@ -41,7 +41,7 @@ impl HasEncoding for OperationsForBlocksMessage {
 }
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct PathRight {
     pub left: Hash,
     pub path: Path,
@@ -56,7 +56,7 @@ impl HasEncoding for PathRight {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct PathLeft {
     pub path: Path,
     pub right: Hash
@@ -71,7 +71,7 @@ impl HasEncoding for PathLeft {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub enum Path {
     Left(Box<PathLeft>),
     Right(Box<PathRight>),

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -9,6 +9,7 @@ dns-lookup = "1.0.1"
 hex = "0.3.2"
 log = "0.4.8"
 riker = { git = "https://github.com/riker-rs/riker" }
+rocksdb = "0.12.3"
 # local dependencies
 networking = { path = "../networking" }
 storage = { path = "../storage" }

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -168,7 +168,7 @@ impl Receive<NetworkChannelMsg> for ChainManager {
                                     debug!("Received current branch from peer: {}", &received.peer);
                                     message.current_branch.history.iter()
                                         .map(|block_hash| block_hash.clone().to_hash_ref())
-                                        .for_each(|block_hash| block_state.schedule_block_hash(block_hash));
+                                        .for_each(|block_hash| block_state.schedule_block_hash(block_hash)?);
                                     // trigger CheckChainCompleteness
                                     ctx.myself().tell(CheckChainCompleteness, None);
                                 }
@@ -178,7 +178,7 @@ impl Receive<NetworkChannelMsg> for ChainManager {
                                 }
                                 PeerMessage::BlockHeader(message) => {
                                     let block_header = BlockHeaderWithHash::new(message.block_header.clone()).unwrap();
-                                    block_state.insert_block_header(block_header.clone());
+                                    block_state.insert_block_header(block_header.clone())?;
                                     if peer.queued_block_headers.remove(&block_header.hash) {
                                         debug!("Received block header from peer: {}", &received.peer);
                                         operations_state.insert_block_header(&block_header);

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -219,7 +219,7 @@ impl Receive<NetworkChannelMsg> for ChainManager {
 
 
                                 }
-                                _ => debug!("Ignored message: {:?}", message)
+                                _ => trace!("Ignored message: {:?}", message)
                             })
                     }
                     None => debug!("Received message for non-existing peer: {}", &received.peer)

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -8,12 +8,10 @@ use riker::actors::*;
 use networking::p2p::encoding::prelude::*;
 use networking::p2p::network_channel::NetworkChannelMsg;
 use networking::p2p::peer::{PeerRef, SendMessage};
-use storage::block_state::BlockState;
-use tezos_encoding::hash::{HashEncoding, HashType, ToHashRef, HashRef};
+use storage::{BlockHeaderWithHash, BlockState, MissingOperations, OperationsState};
+use tezos_encoding::hash::{HashEncoding, HashRef, HashType, ToHashRef};
 
 use crate::{subscribe_to_actor_terminated, subscribe_to_network_events};
-use storage::operations_state::{OperationsState, MissingOperations};
-use storage::BlockHeaderWithHash;
 
 const PEER_QUEUE_MAX: usize = 15;
 const BLOCK_HEADERS_BATCH_SIZE: usize = 10;

--- a/storage/.gitignore
+++ b/storage/.gitignore
@@ -1,0 +1,3 @@
+# Ignore direftories created by DB tests
+/__*
+

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -9,6 +9,6 @@ bincode = "1.1.4"
 bytes = "0.4.12"
 failure = "0.1.5"
 rocksdb = "0.12.3"
-serde = { version = "1.0.101", features = ["derive"] }
+serde = { version = "1.0.101", features = ["derive", "rc"] }
 networking = { path = "../networking" }
 tezos_encoding = { path = "../tezos_encoding" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,10 +5,9 @@ authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 
 [dependencies]
-bincode = "1.1.4"
 bytes = "0.4.12"
 failure = "0.1.5"
+log = "0.4.8"
 rocksdb = "0.12.3"
-serde = { version = "1.0.101", features = ["derive", "rc"] }
 networking = { path = "../networking" }
 tezos_encoding = { path = "../tezos_encoding" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 
 [dependencies]
+rocksdb = "0.12.3"
 networking = { path = "../networking" }
 tezos_encoding = { path = "../tezos_encoding" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 
 [dependencies]
+failure = "0.1.5"
 rocksdb = "0.12.3"
 networking = { path = "../networking" }
 tezos_encoding = { path = "../tezos_encoding" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -5,7 +5,10 @@ authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 
 [dependencies]
+bincode = "1.1.4"
+bytes = "0.4.12"
 failure = "0.1.5"
 rocksdb = "0.12.3"
+serde = { version = "1.0.101", features = ["derive"] }
 networking = { path = "../networking" }
 tezos_encoding = { path = "../tezos_encoding" }

--- a/storage/src/block_state.rs
+++ b/storage/src/block_state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tezos_encoding::hash::{HashRef, ToHashRef};
 
 use crate::block_storage::{BlockStorage, BlockStorageDatabase};
-use crate::BlockHeaderWithHash;
+use crate::{BlockHeaderWithHash, StorageError};
 
 pub struct BlockState {
     storage: BlockStorage,
@@ -19,23 +19,24 @@ impl BlockState {
         }
     }
 
-    pub fn insert_block_header(&mut self, block_header: BlockHeaderWithHash) {
+    pub fn insert_block_header(&mut self, block_header: BlockHeaderWithHash) -> Result<(), StorageError> {
         let predecessor_block_hash = (&block_header.header.predecessor).to_hash_ref();
         // check if we already have seen predecessor
-        if !self.storage.contains(&predecessor_block_hash) {
+        if !self.storage.contains(&predecessor_block_hash)? {
             // block was not seen before
             self.missing_blocks.insert(predecessor_block_hash);
         }
         // remove from missing blocks
         self.missing_blocks.remove(&block_header.hash);
         // store block
-        self.storage.insert(block_header);
+        self.storage.insert(block_header)
     }
 
-    pub fn schedule_block_hash(&mut self, block_hash: HashRef) {
-        if !self.storage.contains(&block_hash) {
-            self.missing_blocks.insert(block_hash);
+    pub fn schedule_block_hash(&mut self, block_hash: HashRef) -> Result<(), StorageError> {
+        if !self.storage.contains(&block_hash)? {
+            self.missing_blocks.insert(block_hash)?;
         }
+        OK(())
     }
 
     pub fn move_to_queue(&mut self, n: usize) -> Vec<HashRef> {

--- a/storage/src/block_state.rs
+++ b/storage/src/block_state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use log::debug;
+use log::trace;
 
 use tezos_encoding::hash::{HashRef, ToHashRef};
 
@@ -36,7 +36,7 @@ impl BlockState {
         if !self.storage.contains(&block_hash)? {
             self.missing_blocks.insert(block_hash);
         } else {
-            debug!("Block {:?} is already present in storage", &block_hash);
+            trace!("Block {:?} is already present in storage", &block_hash);
         }
         Ok(())
     }

--- a/storage/src/block_state.rs
+++ b/storage/src/block_state.rs
@@ -34,9 +34,9 @@ impl BlockState {
 
     pub fn schedule_block_hash(&mut self, block_hash: HashRef) -> Result<(), StorageError> {
         if !self.storage.contains(&block_hash)? {
-            self.missing_blocks.insert(block_hash)?;
+            self.missing_blocks.insert(block_hash);
         }
-        OK(())
+        Ok(())
     }
 
     pub fn move_to_queue(&mut self, n: usize) -> Vec<HashRef> {

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use tezos_encoding::hash::HashRef;
+use tezos_encoding::hash::{HashRef, HashType};
 
 use crate::BlockHeaderWithHash;
 use crate::persistent::{DatabaseWithSchema, Schema};
+use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform};
 
 pub type BlockStorageDatabase = dyn DatabaseWithSchema<BlockStorage> + Sync + Send;
 
@@ -35,4 +36,11 @@ impl Schema for BlockStorage {
     const COLUMN_FAMILY_NAME: &'static str = "block_storage";
     type Key = HashRef;
     type Value = BlockHeaderWithHash;
+
+    fn cf_descriptor() -> ColumnFamilyDescriptor {
+        let mut cf_opts = Options::default();
+        cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(HashType::BlockHash.size()));
+        cf_opts.set_memtable_prefix_bloom_ratio(0.1);
+        ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, cf_opts)
+    }
 }

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tezos_encoding::hash::HashRef;
 
-use crate::BlockHeaderWithHash;
+use crate::{BlockHeaderWithHash, StorageError};
 use crate::persistent::{DatabaseWithSchema, Schema};
 use rocksdb::{ColumnFamilyDescriptor, Options};
 
@@ -19,16 +19,20 @@ impl BlockStorage {
         BlockStorage { db }
     }
 
-    pub fn insert(&mut self, block: BlockHeaderWithHash) {
-        self.db.put(&block.hash, &block).unwrap();
+    pub fn insert(&mut self, block: BlockHeaderWithHash) -> Result<(), StorageError> {
+        self.db.put(&block.hash, &block)
+            .map_err(|e| e.into())
     }
 
-    pub fn get(&self, block_hash: &HashRef) -> Option<BlockHeaderWithHash> {
-        self.db.get(block_hash).unwrap()
+    pub fn get(&self, block_hash: &HashRef) -> Result<Option<BlockHeaderWithHash>, StorageError> {
+        self.db.get(block_hash)
+            .map_err(|e| e.into())
     }
 
-    pub fn contains(&self, block_hash: &HashRef) -> bool {
-        self.get(block_hash).is_some()
+    pub fn contains(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
+        self.get(block_hash)
+            .map_err(|e| e.into())
+            .map(|v| v.is_some())
     }
 }
 

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -1,28 +1,38 @@
-use std::collections::HashMap;
+use std::sync::Arc;
 
 use tezos_encoding::hash::HashRef;
 
 use crate::BlockHeaderWithHash;
+use crate::persistent::{DatabaseWithSchema, Schema};
+
+pub type BlockStorageDatabase = dyn DatabaseWithSchema<BlockStorage> + Sync + Send;
 
 /// Structure for representing in-memory db for - just for demo purposes.
-pub struct BlockStorage(HashMap<HashRef, BlockHeaderWithHash>);
+pub struct BlockStorage {
+    db: Arc<BlockStorageDatabase>
+}
 
 impl BlockStorage {
 
-    pub fn new() -> Self {
-        BlockStorage(HashMap::new())
+    pub fn new(db: Arc<BlockStorageDatabase>) -> Self {
+        BlockStorage { db }
     }
 
     pub fn insert(&mut self, block: BlockHeaderWithHash) {
-        self.0.insert(block.hash.clone(), block);
+        self.db.put(&block.hash, &block).unwrap();
     }
 
-    pub fn get(&self, block_hash: &HashRef) -> Option<&BlockHeaderWithHash> {
-        self.0.get(block_hash)
+    pub fn get(&self, block_hash: &HashRef) -> Option<BlockHeaderWithHash> {
+        self.db.get(block_hash).unwrap()
     }
 
-    pub fn is_present(&self, block_hash: &HashRef) -> bool {
-        self.0.contains_key(block_hash)
+    pub fn contains(&self, block_hash: &HashRef) -> bool {
+        self.get(block_hash).is_some()
     }
 }
 
+impl Schema for BlockStorage {
+    const COLUMN_FAMILY_NAME: &'static str = "block_storage";
+    type Key = HashRef;
+    type Value = BlockHeaderWithHash;
+}

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -30,7 +30,7 @@ impl BlockStorage {
 
     pub fn contains(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
         self.get(block_hash)
-            .map_err(|e| e.into())
+            .map_err(StorageError::from)
             .map(|v| v.is_some())
     }
 }

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use tezos_encoding::hash::{HashRef, HashType};
+use tezos_encoding::hash::HashRef;
 
 use crate::BlockHeaderWithHash;
 use crate::persistent::{DatabaseWithSchema, Schema};
-use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform};
+use rocksdb::{ColumnFamilyDescriptor, Options};
 
 pub type BlockStorageDatabase = dyn DatabaseWithSchema<BlockStorage> + Sync + Send;
 
@@ -38,9 +38,6 @@ impl Schema for BlockStorage {
     type Value = BlockHeaderWithHash;
 
     fn cf_descriptor() -> ColumnFamilyDescriptor {
-        let mut cf_opts = Options::default();
-        cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(HashType::BlockHash.size()));
-        cf_opts.set_memtable_prefix_bloom_ratio(0.1);
-        ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, cf_opts)
+        ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, Options::default())
     }
 }

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -4,7 +4,6 @@ use tezos_encoding::hash::HashRef;
 
 use crate::{BlockHeaderWithHash, StorageError};
 use crate::persistent::{DatabaseWithSchema, Schema};
-use rocksdb::{ColumnFamilyDescriptor, Options};
 
 pub type BlockStorageDatabase = dyn DatabaseWithSchema<BlockStorage> + Sync + Send;
 

--- a/storage/src/block_storage.rs
+++ b/storage/src/block_storage.rs
@@ -40,8 +40,4 @@ impl Schema for BlockStorage {
     const COLUMN_FAMILY_NAME: &'static str = "block_storage";
     type Key = HashRef;
     type Value = BlockHeaderWithHash;
-
-    fn cf_descriptor() -> ColumnFamilyDescriptor {
-        ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, Options::default())
-    }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,12 +1,14 @@
 use std::sync::Arc;
 
+use failure::Fail;
+
 pub use block_state::BlockState;
-use networking::p2p::binary_message::{MessageHash, MessageHashError, BinaryMessage};
+use networking::p2p::binary_message::{BinaryMessage, MessageHash, MessageHashError};
 use networking::p2p::encoding::prelude::BlockHeader;
 pub use operations_state::{MissingOperations, OperationsState};
 use tezos_encoding::hash::{HashRef, ToHashRef};
 
-use crate::persistent::{Codec, SchemaError};
+use crate::persistent::{Codec, DBError, SchemaError};
 
 pub mod persistent;
 pub mod block_storage;
@@ -15,7 +17,7 @@ pub mod operations_state;
 pub mod block_state;
 
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct BlockHeaderWithHash {
     pub header: Arc<BlockHeader>,
     pub hash: HashRef,
@@ -32,16 +34,63 @@ impl BlockHeaderWithHash {
 
 impl Codec for BlockHeaderWithHash {
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-        let block_header = BlockHeader::from_bytes(bytes.to_vec())
-            .map_err(|_| SchemaError::DecodeError)?;
-
-        BlockHeaderWithHash::new(block_header)
+        bincode::deserialize(bytes)
             .map_err(|_| SchemaError::DecodeError)
     }
 
     fn encode(&self) -> Result<Vec<u8>, SchemaError> {
-        self.header.as_bytes()
-            .map_err(|_| SchemaError::EncodeError)
+        bincode::serialize(self)
+            .map_err(|_| SchemaError::DecodeError)
     }
 }
 
+/// Possible errors for storage
+#[derive(Debug, Fail)]
+pub enum StorageError {
+    #[fail(display = "Database error: {}", error)]
+    DBError {
+        error: DBError
+    },
+    #[fail(display = "Key is missing in storage")]
+    MissingKey,
+    #[fail(display = "Unexpected value found in storage")]
+    UnexpectedValue
+}
+
+impl From<DBError> for StorageError {
+    fn from(error: DBError) -> Self {
+        StorageError::DBError { error }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::FromIterator;
+
+    use failure::Error;
+
+    use tezos_encoding::hash::{HashEncoding, HashType};
+
+    use super::*;
+
+    #[test]
+    fn block_header_with_hash_encoded_equals_decoded() -> Result<(), Error> {
+        let expected = BlockHeaderWithHash {
+            hash: HashRef::new(HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?),
+            header: Arc::new(BlockHeader {
+                level: 34,
+                proto: 1,
+                predecessor: HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?,
+                timestamp: 5635634,
+                validation_pass: 4,
+                operations_hash: HashEncoding::new(HashType::OperationListListHash).string_to_bytes("LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc")?,
+                fitness: vec![vec![0, 0]],
+                context: HashEncoding::new(HashType::ContextHash).string_to_bytes("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
+                protocol_data: vec![0, 1, 2, 3, 4, 5, 6, 7, 8]
+            })
+        };
+        let encoded_bytes = expected.encode()?;
+        let decoded = BlockHeaderWithHash::decode(&encoded_bytes)?;
+        Ok(assert_eq!(expected, decoded))
+    }
+}

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,7 +3,7 @@ use serde::{Serialize, Deserialize};
 use failure::Fail;
 
 pub use block_state::BlockState;
-use networking::p2p::binary_message::{BinaryMessage, MessageHash, MessageHashError};
+use networking::p2p::binary_message::{MessageHash, MessageHashError};
 use networking::p2p::encoding::prelude::BlockHeader;
 pub use operations_state::{MissingOperations, OperationsState};
 use tezos_encoding::hash::{HashRef, ToHashRef};

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -7,6 +7,7 @@ pub mod block_storage;
 pub mod operations_storage;
 pub mod operations_state;
 pub mod block_state;
+pub mod persistent;
 
 
 #[derive(Clone)]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-
+use serde::{Serialize, Deserialize};
 use failure::Fail;
 
 pub use block_state::BlockState;
@@ -17,7 +17,7 @@ pub mod operations_state;
 pub mod block_state;
 
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct BlockHeaderWithHash {
     pub header: Arc<BlockHeader>,
     pub hash: HashRef,
@@ -32,6 +32,7 @@ impl BlockHeaderWithHash {
     }
 }
 
+/// Codec for `BlockHeaderWithHash`
 impl Codec for BlockHeaderWithHash {
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
         bincode::deserialize(bytes)
@@ -53,8 +54,6 @@ pub enum StorageError {
     },
     #[fail(display = "Key is missing in storage")]
     MissingKey,
-    #[fail(display = "Unexpected value found in storage")]
-    UnexpectedValue
 }
 
 impl From<DBError> for StorageError {

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -1,11 +1,16 @@
-use networking::p2p::binary_message::{MessageHash, MessageHashError};
-use networking::p2p::encoding::prelude::BlockHeader;
-use tezos_encoding::hash::{HashRef, ToHashRef};
 use std::sync::Arc;
 
-mod persistent;
-mod block_storage;
-mod operations_storage;
+pub use block_state::BlockState;
+use networking::p2p::binary_message::{MessageHash, MessageHashError, BinaryMessage};
+use networking::p2p::encoding::prelude::BlockHeader;
+pub use operations_state::{MissingOperations, OperationsState};
+use tezos_encoding::hash::{HashRef, ToHashRef};
+
+use crate::persistent::{Codec, SchemaError};
+
+pub mod persistent;
+pub mod block_storage;
+pub mod operations_storage;
 pub mod operations_state;
 pub mod block_state;
 
@@ -25,5 +30,18 @@ impl BlockHeaderWithHash {
     }
 }
 
-pub use block_state::BlockState;
-pub use operations_state::{OperationsState, MissingOperations};
+impl Codec for BlockHeaderWithHash {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        let block_header = BlockHeader::from_bytes(bytes.to_vec())
+            .map_err(|_| SchemaError::DecodeError)?;
+
+        BlockHeaderWithHash::new(block_header)
+            .map_err(|_| SchemaError::DecodeError)
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        self.header.as_bytes()
+            .map_err(|_| SchemaError::EncodeError)
+    }
+}
+

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,7 +3,7 @@ use networking::p2p::encoding::prelude::BlockHeader;
 use tezos_encoding::hash::{HashRef, ToHashRef};
 use std::sync::Arc;
 
-//mod persistent;
+mod persistent;
 mod block_storage;
 mod operations_storage;
 pub mod operations_state;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -3,11 +3,11 @@ use networking::p2p::encoding::prelude::BlockHeader;
 use tezos_encoding::hash::{HashRef, ToHashRef};
 use std::sync::Arc;
 
-pub mod block_storage;
-pub mod operations_storage;
+//mod persistent;
+mod block_storage;
+mod operations_storage;
 pub mod operations_state;
 pub mod block_state;
-pub mod persistent;
 
 
 #[derive(Clone)]
@@ -24,3 +24,6 @@ impl BlockHeaderWithHash {
         })
     }
 }
+
+pub use block_state::BlockState;
+pub use operations_state::{OperationsState, MissingOperations};

--- a/storage/src/operations_state.rs
+++ b/storage/src/operations_state.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use networking::p2p::encoding::prelude::*;
-use tezos_encoding::hash::{HashRef, ToHashRef};
+use tezos_encoding::hash::HashRef;
 
 use crate::{BlockHeaderWithHash, StorageError};
 use crate::operations_storage::{OperationsMetaStorage, OperationsStorage, OperationsStorageDatabase, OperationsMetaStorageDatabase};

--- a/storage/src/operations_state.rs
+++ b/storage/src/operations_state.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use log::debug;
+use log::trace;
 
 use networking::p2p::encoding::prelude::*;
 use tezos_encoding::hash::HashRef;
@@ -40,7 +40,7 @@ impl OperationsState {
 
         self.meta_storage.insert(message)?;
         if self.meta_storage.is_complete(&hash_ref)? {
-            debug!("Block {:?} has complete operations", &hash_ref);
+            trace!("Block {:?} has complete operations", &hash_ref);
             self.missing_operations_for_blocks.remove(&hash_ref);
         }
         Ok(())
@@ -64,7 +64,7 @@ impl OperationsState {
             if !self.meta_storage.is_complete(&op.block_hash)? {
                 self.missing_operations_for_blocks.insert(op.block_hash);
             } else {
-                debug!("Will not re-queue block {:?} because it has complete operations", &op.block_hash);
+                trace!("Will not re-queue block {:?} because it has complete operations", &op.block_hash);
             }
         }
         Ok(())

--- a/storage/src/operations_state.rs
+++ b/storage/src/operations_state.rs
@@ -22,7 +22,7 @@ impl OperationsState {
     }
 
     pub fn insert_block_header(&mut self, block_header: &BlockHeaderWithHash) {
-        if !self.storage.is_present(&block_header.hash) {
+        if !self.storage.contains(&block_header.hash) {
             self.storage.initialize_operations(block_header);
             self.missing_operations_for_blocks.insert(block_header.hash.clone());
         }
@@ -39,7 +39,7 @@ impl OperationsState {
     }
 
     pub fn schedule_block_hash(&mut self, block_hash: HashRef) {
-        if !self.storage.is_present(&block_hash) {
+        if !self.storage.contains(&block_hash) {
             self.missing_operations_for_blocks.insert(block_hash);
         }
     }

--- a/storage/src/operations_storage.rs
+++ b/storage/src/operations_storage.rs
@@ -1,129 +1,282 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
-use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform};
+use bytes::{Buf, BufMut, IntoBuf};
+use rocksdb::{ColumnFamilyDescriptor, Options, SliceTransform, MergeOperands};
+use serde::{Deserialize, Serialize};
 
 use networking::p2p::encoding::prelude::*;
-use tezos_encoding::hash::{HashRef, HashType, BlockHash};
+use tezos_encoding::hash::{BlockHash, HashRef, HashType};
 
-use crate::BlockHeaderWithHash;
-use crate::persistent::{Schema, Codec, SchemaError};
+use crate::{BlockHeaderWithHash, StorageError};
+use crate::persistent::{Codec, Schema, SchemaError, DatabaseWithSchema};
+use std::sync::Arc;
 
-pub struct Operations {
-    pub(crate) block_hash: HashRef,
-    values: Vec<Option<OperationsForBlocksMessage>>
+pub type OperationsStorageDatabase = dyn DatabaseWithSchema<OperationsStorage> + Sync + Send;
+
+pub struct OperationsStorage {
+    db: Arc<OperationsStorageDatabase>
 }
-
-impl PartialEq for Operations {
-    fn eq(&self, other: &Self) -> bool {
-        self.block_hash == other.block_hash
-    }
-}
-
-impl Eq for Operations {}
-
-impl Hash for Operations {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.block_hash.hash(state);
-    }
-}
-
-impl Operations {
-
-    pub fn insert(&mut self, value: OperationsForBlocksMessage) {
-        let op_idx = value.operations_for_block.validation_pass as usize;
-        self.values[op_idx] = Some(value);
-    }
-
-    pub fn is_complete(&self) -> bool {
-        self.values.iter().all(Option::is_some)
-    }
-
-    pub fn get_missing_validation_passes(&self) -> HashSet<i8> {
-        self.values.iter().enumerate()
-            .filter(|(_, value)| value.is_none())
-            .map(|(idx, _)| idx as i8)
-            .collect()
-    }
-}
-
-/// Structure for representing in-memory db for - just for demo purposes.
-pub struct OperationsStorage(HashMap<HashRef, Operations>);
 
 impl OperationsStorage {
-
-    pub fn new() -> Self {
-        OperationsStorage(HashMap::new())
+    pub fn new(db: Arc<OperationsStorageDatabase>) -> Self {
+        OperationsStorage { db }
     }
 
-    pub fn initialize_operations(&mut self, block_header: &BlockHeaderWithHash) {
-        let operations = Operations {
-            block_hash: block_header.hash.clone(),
-            values: vec![None; block_header.header.validation_pass as usize],
-        };
-        self.0.insert(block_header.hash.clone(), operations);
+    pub fn initialize(&mut self, block_header: &BlockHeaderWithHash) -> Result<(), StorageError> {
+        self.db.put(
+            &OperationKey::Meta {
+                block_hash: block_header.hash.clone()
+            },
+            &OperationValue::Meta {
+                validation_passes: block_header.header.validation_pass,
+                is_validation_pass_present: vec![false as u8; block_header.header.validation_pass as usize],
+                is_complete: false
+            }
+        ).map_err(|e| e.into())
     }
 
-    pub fn get_operations_mut(&mut self, block_hash: &HashRef) -> Option<&mut Operations> {
-        self.0.get_mut(block_hash)
+    pub fn insert(&mut self, message: OperationsForBlocksMessage) -> Result<(), StorageError> {
+        let block_hash =  HashRef::new(message.operations_for_block.hash.clone());
+        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
+
+        match self.db.get(&meta_key)? {
+            Some(OperationValue::Meta { mut is_validation_pass_present, is_complete, validation_passes }) => {
+                let validation_pass = u8::from(message.operations_for_block.validation_pass);
+
+                // update validation passes and check if we have all operations
+                is_validation_pass_present[validation_pass as usize] = true as u8;
+                let is_complete = is_validation_pass_present.iter().all(|v| *v == (true as u8));
+                self.db.merge(&meta_key, &OperationValue::Meta { is_validation_pass_present, validation_passes, is_complete })?;
+
+                // store value of the message
+                let message_key = OperationKey::Message {
+                    block_hash: block_hash.clone(),
+                    validation_pass
+                };
+                let message_value = OperationValue::Message { message };
+                self.db.put(&message_key, &message_value)
+                    .map_err(|e| e.into())
+            }
+            None => Err(StorageError::MissingKey),
+            _ => Err(StorageError::UnexpectedValue)
+        }
     }
 
-    pub fn get_operations(&mut self, block_hash: &HashRef) -> Option<&Operations> {
-        self.0.get(block_hash)
+    pub fn get_missing_validation_passes(&mut self, block_hash: &HashRef) -> Result<HashSet<i8>, StorageError> {
+        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
+        match self.db.get(&meta_key)? {
+            Some(OperationValue::Meta { is_complete, is_validation_pass_present, .. }) => {
+                let result  = if is_complete {
+                    HashSet::new()
+                } else {
+                    missing_validation_passes.iter().enumerate()
+                        .filter(|(_, is_present)| **is_present == (true as u8))
+                        .map(|(idx, _)| idx as i8)
+                        .collect()
+                };
+                Ok(result)
+            }
+            None => Err(StorageError::MissingKey),
+            _ => Err(StorageError::UnexpectedValue)
+        }
     }
 
-    pub fn contains(&self, block_hash: &HashRef) -> bool {
-        self.0.contains_key(block_hash)
+    pub fn is_complete(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
+        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
+        match self.db.get(&meta_key)? {
+            Some(OperationValue::Meta { is_complete, .. }) => {
+                Ok(is_complete)
+            }
+            None => Err(StorageError::MissingKey),
+            _ => Err(StorageError::UnexpectedValue)
+        }
+    }
+
+
+    pub fn contains_operations(&self, block_hash: &HashRef) -> bool {
+        self.db.get(&OperationKey::Meta { block_hash: block_hash.clone() }).unwrap().is_some()
     }
 }
 
-enum KeyType {
-    Meta,
+const KEY_META_VARIANT_ID: u8 = 0;
+const KEY_MESSAGE_VARIANT_ID: u8 = 1;
+const VALUE_META_VARIANT_ID: u8 = 0xf0;
+const VALUE_MESSAGE_VARIANT_ID: u8 = 0xf1;
+
+
+/// Layout of the `OperationKey` is:
+/// `[block_hash][variant_id]<validation_pass>`
+#[derive(Debug, PartialEq)]
+pub enum OperationKey {
+    Meta {
+        block_hash: HashRef,
+    },
     Message {
-        validation_pass: u8
-    }
-}
-
-struct OperationKey {
-    block_hash: BlockHash,
-    key_type: KeyType
+        block_hash: HashRef,
+        validation_pass: u8,
+    },
 }
 
 impl Codec for OperationKey {
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-        let block_hash_size = HashType::BlockHash.size();
-        let block_hash = bytes[0..block_hash_size].to_vec();
-        let key_type = match bytes[block_hash_size] {
-            0 => KeyType::Meta,
-            1 => KeyType::Message { validation_pass: block_hash[block_hash_size + 1] }
-            _ => SchemaError::DecodeError
-        };
-        Ok(OperationKey { block_hash, key_type })
+        let mut buf = bytes.to_vec().into_buf();
+        let mut block_hash = vec![0; HashType::BlockHash.size()];
+        buf.copy_to_slice(&mut block_hash);
+        match buf.get_u8() {
+            KEY_META_VARIANT_ID => Ok(OperationKey::Meta {
+                block_hash: HashRef::new(block_hash)
+            }),
+            KEY_MESSAGE_VARIANT_ID => Ok(OperationKey::Message {
+                block_hash: HashRef::new(block_hash),
+                validation_pass: buf.get_u8(),
+            }),
+            _ => Err(SchemaError::DecodeError)
+        }
     }
 
     fn encode(&self) -> Result<Vec<u8>, SchemaError> {
-        let mut value = self.block_hash.clone();
-        match self.key_type {
-            KeyType::Meta => value.push(0),
-            KeyType::Message { validation_pass } => {
-                value.push(1);
-                value.push(validation_pass);
+        let mut value = vec![];
+        match self {
+            OperationKey::Meta { block_hash } => {
+                value.extend(&block_hash.hash);
+                value.put_u8(KEY_META_VARIANT_ID);
+            }
+            OperationKey::Message { block_hash, validation_pass } => {
+                value.extend(&block_hash.hash);
+                value.put_u8(KEY_MESSAGE_VARIANT_ID);
+                value.put_u8(*validation_pass);
             }
         }
         Ok(value)
     }
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub enum OperationValue {
+    Meta {
+        is_validation_pass_present: Vec<u8>,
+        validation_passes: u8,
+        is_complete: bool
+    },
+    Message {
+        message: OperationsForBlocksMessage
+    },
+}
+
+impl Codec for OperationValue {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        bincode::deserialize(&bytes[1..])
+            .map_err(|_| SchemaError::DecodeError)
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        bincode::serialize(self)
+            .map_err(|_| SchemaError::DecodeError)
+    }
+}
+
+
 impl Schema for OperationsStorage {
     const COLUMN_FAMILY_NAME: &'static str = "operations_storage";
     type Key = OperationKey;
-    type Value = ();
+    type Value = OperationValue;
 
     fn cf_descriptor() -> ColumnFamilyDescriptor {
         let mut cf_opts = Options::default();
         cf_opts.set_prefix_extractor(SliceTransform::create_fixed_prefix(HashType::BlockHash.size()));
         cf_opts.set_memtable_prefix_bloom_ratio(0.2);
+        cf_opts.set_merge_operator("operations_storage_merge_operator", merge_meta_value, None);
         ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, cf_opts)
     }
+}
 
+fn merge_meta_value(new_key: &[u8], existing_val: Option<&[u8]>, operands: &mut MergeOperands) -> Option<Vec<u8>> {
+
+   let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
+   existing_val.map(|v| {
+       for e in v {
+           result.push(*e)
+       }
+   });
+   for op in operands {
+       for e in op {
+           result.push(*e)
+       }
+   }
+   Some(result)
+}
+
+#[derive(Clone)]
+pub struct MissingOperations {
+    pub block_hash: HashRef,
+    pub validation_passes: HashSet<i8>
+}
+
+impl PartialEq for MissingOperations {
+    fn eq(&self, other: &Self) -> bool {
+        self.block_hash == other.block_hash
+    }
+}
+
+impl Eq for MissingOperations {}
+
+impl Hash for MissingOperations {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.block_hash.hash(state);
+    }
+}
+
+
+impl From<&MissingOperations> for Vec<OperationsForBlock> {
+    fn from(ops: &MissingOperations) -> Self {
+        ops.validation_passes
+            .iter()
+            .map(|vp| {
+                OperationsForBlock {
+                    hash: ops.block_hash.get_hash(),
+                    validation_pass: *vp
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use failure::Error;
+    use tezos_encoding::hash::HashEncoding;
+
+    use super::*;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn operations_key_encoded_equals_decoded() -> Result<(), Error> {
+        let expected = OperationKey::Meta {
+            block_hash: HashRef::new(HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?)
+        };
+        let encoded_bytes = expected.encode()?;
+        let decoded = OperationKey::decode(&encoded_bytes)?;
+        assert_eq!(expected, decoded);
+
+        let expected = OperationKey::Message {
+            block_hash: HashRef::new(HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?),
+            validation_pass: 4,
+        };
+        let encoded_bytes = expected.encode()?;
+        let decoded = OperationKey::decode(&encoded_bytes)?;
+        Ok(assert_eq!(expected, decoded))
+    }
+
+    #[test]
+    fn operations_value_encoded_equals_decoded() -> Result<(), Error> {
+        let expected = OperationValue::Meta {
+            is_validation_pass_present: vec![false as u8; 5],
+            is_complete: false,
+            validation_passes: 5
+        };
+        let encoded_bytes = expected.encode()?;
+        let decoded = OperationValue::decode(&encoded_bytes)?;
+        Ok(assert_eq!(expected, decoded))
+    }
 }

--- a/storage/src/operations_storage.rs
+++ b/storage/src/operations_storage.rs
@@ -53,10 +53,6 @@ impl OperationsStorage {
         OperationsStorage(HashMap::new())
     }
 
-    pub fn contains_block_hash(&self, block_hash: &HashRef) -> bool {
-        self.0.contains_key(block_hash)
-    }
-
     pub fn initialize_operations(&mut self, block_header: &BlockHeaderWithHash) {
         let operations = Operations {
             block_hash: block_header.hash.clone(),
@@ -73,7 +69,7 @@ impl OperationsStorage {
         self.0.get(block_hash)
     }
 
-    pub fn is_present(&self, block_hash: &HashRef) -> bool {
+    pub fn contains(&self, block_hash: &HashRef) -> bool {
         self.0.contains_key(block_hash)
     }
 }

--- a/storage/src/operations_storage.rs
+++ b/storage/src/operations_storage.rs
@@ -11,8 +11,10 @@ use tezos_encoding::hash::{BlockHash, HashRef, HashType};
 use crate::{BlockHeaderWithHash, StorageError};
 use crate::persistent::{Codec, Schema, SchemaError, DatabaseWithSchema};
 use std::sync::Arc;
+use std::convert::TryFrom;
 
 pub type OperationsStorageDatabase = dyn DatabaseWithSchema<OperationsStorage> + Sync + Send;
+
 
 pub struct OperationsStorage {
     db: Arc<OperationsStorageDatabase>
@@ -23,164 +25,20 @@ impl OperationsStorage {
         OperationsStorage { db }
     }
 
-    pub fn initialize(&mut self, block_header: &BlockHeaderWithHash) -> Result<(), StorageError> {
-        self.db.put(
-            &OperationKey::Meta {
-                block_hash: block_header.hash.clone()
-            },
-            &OperationValue::Meta {
-                validation_passes: block_header.header.validation_pass,
-                is_validation_pass_present: vec![false as u8; block_header.header.validation_pass as usize],
-                is_complete: false
-            }
-        ).map_err(|e| e.into())
-    }
-
-    pub fn insert(&mut self, message: OperationsForBlocksMessage) -> Result<(), StorageError> {
-        let block_hash =  HashRef::new(message.operations_for_block.hash.clone());
-        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
-
-        match self.db.get(&meta_key)? {
-            Some(OperationValue::Meta { mut is_validation_pass_present, is_complete, validation_passes }) => {
-                let validation_pass = u8::from(message.operations_for_block.validation_pass);
-
-                // update validation passes and check if we have all operations
-                is_validation_pass_present[validation_pass as usize] = true as u8;
-                let is_complete = is_validation_pass_present.iter().all(|v| *v == (true as u8));
-                self.db.merge(&meta_key, &OperationValue::Meta { is_validation_pass_present, validation_passes, is_complete })?;
-
-                // store value of the message
-                let message_key = OperationKey::Message {
-                    block_hash: block_hash.clone(),
-                    validation_pass
-                };
-                let message_value = OperationValue::Message { message };
-                self.db.put(&message_key, &message_value)
-                    .map_err(|e| e.into())
-            }
-            None => Err(StorageError::MissingKey),
-            _ => Err(StorageError::UnexpectedValue)
-        }
-    }
-
-    pub fn get_missing_validation_passes(&mut self, block_hash: &HashRef) -> Result<HashSet<i8>, StorageError> {
-        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
-        match self.db.get(&meta_key)? {
-            Some(OperationValue::Meta { is_complete, is_validation_pass_present, .. }) => {
-                let result  = if is_complete {
-                    HashSet::new()
-                } else {
-                    missing_validation_passes.iter().enumerate()
-                        .filter(|(_, is_present)| **is_present == (true as u8))
-                        .map(|(idx, _)| idx as i8)
-                        .collect()
-                };
-                Ok(result)
-            }
-            None => Err(StorageError::MissingKey),
-            _ => Err(StorageError::UnexpectedValue)
-        }
-    }
-
-    pub fn is_complete(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
-        let meta_key = OperationKey::Meta { block_hash: block_hash.clone() };
-        match self.db.get(&meta_key)? {
-            Some(OperationValue::Meta { is_complete, .. }) => {
-                Ok(is_complete)
-            }
-            None => Err(StorageError::MissingKey),
-            _ => Err(StorageError::UnexpectedValue)
-        }
-    }
-
-
-    pub fn contains_operations(&self, block_hash: &HashRef) -> bool {
-        self.db.get(&OperationKey::Meta { block_hash: block_hash.clone() }).unwrap().is_some()
+    pub fn insert(&mut self, message: &OperationsForBlocksMessage) -> Result<(), StorageError> {
+        let key = OperationKey {
+            block_hash: HashRef::new(message.operations_for_block.hash.clone()),
+            validation_pass: message.operations_for_block.validation_pass as u8
+        };
+        self.db.put(&key, &message)
+            .map_err(|e| e.into())
     }
 }
-
-const KEY_META_VARIANT_ID: u8 = 0;
-const KEY_MESSAGE_VARIANT_ID: u8 = 1;
-const VALUE_META_VARIANT_ID: u8 = 0xf0;
-const VALUE_MESSAGE_VARIANT_ID: u8 = 0xf1;
-
-
-/// Layout of the `OperationKey` is:
-/// `[block_hash][variant_id]<validation_pass>`
-#[derive(Debug, PartialEq)]
-pub enum OperationKey {
-    Meta {
-        block_hash: HashRef,
-    },
-    Message {
-        block_hash: HashRef,
-        validation_pass: u8,
-    },
-}
-
-impl Codec for OperationKey {
-    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-        let mut buf = bytes.to_vec().into_buf();
-        let mut block_hash = vec![0; HashType::BlockHash.size()];
-        buf.copy_to_slice(&mut block_hash);
-        match buf.get_u8() {
-            KEY_META_VARIANT_ID => Ok(OperationKey::Meta {
-                block_hash: HashRef::new(block_hash)
-            }),
-            KEY_MESSAGE_VARIANT_ID => Ok(OperationKey::Message {
-                block_hash: HashRef::new(block_hash),
-                validation_pass: buf.get_u8(),
-            }),
-            _ => Err(SchemaError::DecodeError)
-        }
-    }
-
-    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
-        let mut value = vec![];
-        match self {
-            OperationKey::Meta { block_hash } => {
-                value.extend(&block_hash.hash);
-                value.put_u8(KEY_META_VARIANT_ID);
-            }
-            OperationKey::Message { block_hash, validation_pass } => {
-                value.extend(&block_hash.hash);
-                value.put_u8(KEY_MESSAGE_VARIANT_ID);
-                value.put_u8(*validation_pass);
-            }
-        }
-        Ok(value)
-    }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-pub enum OperationValue {
-    Meta {
-        is_validation_pass_present: Vec<u8>,
-        validation_passes: u8,
-        is_complete: bool
-    },
-    Message {
-        message: OperationsForBlocksMessage
-    },
-}
-
-impl Codec for OperationValue {
-    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-        bincode::deserialize(&bytes[1..])
-            .map_err(|_| SchemaError::DecodeError)
-    }
-
-    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
-        bincode::serialize(self)
-            .map_err(|_| SchemaError::DecodeError)
-    }
-}
-
 
 impl Schema for OperationsStorage {
     const COLUMN_FAMILY_NAME: &'static str = "operations_storage";
     type Key = OperationKey;
-    type Value = OperationValue;
+    type Value = OperationsForBlocksMessage;
 
     fn cf_descriptor() -> ColumnFamilyDescriptor {
         let mut cf_opts = Options::default();
@@ -191,54 +49,155 @@ impl Schema for OperationsStorage {
     }
 }
 
+/// Layout of the `OperationKey` is:
+///
+/// * bytes layout: `[block_hash(32)][validation_pass(1)]`
+#[derive(Debug, PartialEq)]
+pub struct OperationKey {
+    block_hash: HashRef,
+    validation_pass: u8,
+}
+
+impl Codec for OperationKey {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        Ok(OperationKey {
+            block_hash: HashRef::new(bytes[0..HashType::BlockHash.size()].to_vec()),
+            validation_pass: bytes[HashType::BlockHash.size()]
+        })
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        let mut value = Vec::with_capacity(HashType::BlockHash.size() + 1);
+        value.extend(&*self.block_hash.hash);
+        value[HashType::BlockHash.size()] = self.validation_pass;
+        Ok(value)
+    }
+}
+
+impl Codec for OperationsForBlocksMessage {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        bincode::deserialize(bytes)
+            .map_err(|_| SchemaError::DecodeError)
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        bincode::serialize(self)
+            .map_err(|_| SchemaError::DecodeError)
+    }
+}
+
+
 fn merge_meta_value(new_key: &[u8], existing_val: Option<&[u8]>, operands: &mut MergeOperands) -> Option<Vec<u8>> {
 
-   let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
-   existing_val.map(|v| {
-       for e in v {
-           result.push(*e)
-       }
-   });
-   for op in operands {
-       for e in op {
-           result.push(*e)
-       }
-   }
-   Some(result)
+    let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
+    existing_val.map(|v| {
+        for e in v {
+            result.push(*e)
+        }
+    });
+    for op in operands {
+        for e in op {
+            result.push(*e)
+        }
+    }
+    Some(result)
 }
 
-#[derive(Clone)]
-pub struct MissingOperations {
-    pub block_hash: HashRef,
-    pub validation_passes: HashSet<i8>
+/// Convenience type for operation meta storage database
+pub type OperationsMetaStorageDatabase = dyn DatabaseWithSchema<OperationsMetaStorage> + Sync + Send;
+
+pub struct OperationsMetaStorage {
+    db: Arc<OperationsMetaStorageDatabase>
 }
 
-impl PartialEq for MissingOperations {
-    fn eq(&self, other: &Self) -> bool {
-        self.block_hash == other.block_hash
+impl OperationsMetaStorage {
+    pub fn new(db: Arc<OperationsMetaStorageDatabase>) -> Self {
+        OperationsMetaStorage { db }
+    }
+
+    pub fn initialize(&mut self, block_header: &BlockHeaderWithHash) -> Result<(), StorageError> {
+        self.db.put(&block_header.hash.clone(),
+            &Meta {
+                validation_passes: block_header.header.validation_pass,
+                is_validation_pass_present: vec![false as u8; block_header.header.validation_pass as usize],
+                is_complete: false
+            }
+        ).map_err(|e| e.into())
+    }
+
+    pub fn insert(&mut self, message: &OperationsForBlocksMessage) -> Result<(), StorageError> {
+        let block_hash =  HashRef::new(message.operations_for_block.hash.clone());
+
+        match self.db.get(&block_hash)? {
+            Some(mut meta) => {
+                let validation_pass = message.operations_for_block.validation_pass as u8;
+
+                // update validation passes and check if we have all operations
+                meta.is_validation_pass_present[validation_pass as usize] = true as u8;
+                meta.is_complete = meta.is_validation_pass_present.iter().all(|v| *v == (true as u8));
+                self.db.merge(&block_hash, &meta)
+                    .map_err(|e| e.into())
+            }
+            None => Err(StorageError::MissingKey),
+        }
+    }
+
+    pub fn get_missing_validation_passes(&mut self, block_hash: &HashRef) -> Result<HashSet<i8>, StorageError> {
+        match self.db.get(block_hash)? {
+            Some(meta) => {
+                let result  = if meta.is_complete {
+                    HashSet::new()
+                } else {
+                    meta.is_validation_pass_present.iter().enumerate()
+                        .filter(|(_, is_present)| **is_present == (false as u8))
+                        .map(|(idx, _)| idx as i8)
+                        .collect()
+                };
+                Ok(result)
+            }
+            None => Err(StorageError::MissingKey),
+        }
+    }
+
+    pub fn is_complete(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
+        match self.db.get(block_hash)? {
+            Some(Meta { is_complete, .. }) => {
+                Ok(is_complete)
+            }
+            None => Ok(false),
+        }
+    }
+
+
+    pub fn contains(&self, block_hash: &HashRef) -> Result<bool, StorageError> {
+        self.db.get(block_hash)
+            .map(|v| v.is_some())
+            .map_err(StorageError::from)
     }
 }
 
-impl Eq for MissingOperations {}
-
-impl Hash for MissingOperations {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.block_hash.hash(state);
-    }
+impl Schema for OperationsMetaStorage {
+    const COLUMN_FAMILY_NAME: &'static str = "operations_meta_storage";
+    type Key = HashRef;
+    type Value = Meta;
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct Meta {
+    is_validation_pass_present: Vec<u8>,
+    validation_passes: u8,
+    is_complete: bool
+}
 
-impl From<&MissingOperations> for Vec<OperationsForBlock> {
-    fn from(ops: &MissingOperations) -> Self {
-        ops.validation_passes
-            .iter()
-            .map(|vp| {
-                OperationsForBlock {
-                    hash: ops.block_hash.get_hash(),
-                    validation_pass: *vp
-                }
-            })
-            .collect()
+impl Codec for Meta {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        bincode::deserialize(bytes)
+            .map_err(|_| SchemaError::DecodeError)
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        bincode::serialize(self)
+            .map_err(|_| SchemaError::DecodeError)
     }
 }
 
@@ -252,13 +211,6 @@ mod tests {
 
     #[test]
     fn operations_key_encoded_equals_decoded() -> Result<(), Error> {
-        let expected = OperationKey::Meta {
-            block_hash: HashRef::new(HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?)
-        };
-        let encoded_bytes = expected.encode()?;
-        let decoded = OperationKey::decode(&encoded_bytes)?;
-        assert_eq!(expected, decoded);
-
         let expected = OperationKey::Message {
             block_hash: HashRef::new(HashEncoding::new(HashType::BlockHash).string_to_bytes("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?),
             validation_pass: 4,
@@ -269,8 +221,8 @@ mod tests {
     }
 
     #[test]
-    fn operations_value_encoded_equals_decoded() -> Result<(), Error> {
-        let expected = OperationValue::Meta {
+    fn operations_meta_encoded_equals_decoded() -> Result<(), Error> {
+        let expected = Meta {
             is_validation_pass_present: vec![false as u8; 5],
             is_complete: false,
             validation_passes: 5

--- a/storage/src/persistent/database.rs
+++ b/storage/src/persistent/database.rs
@@ -1,0 +1,35 @@
+use rocksdb::{DB, ReadOptions, WriteOptions};
+
+use crate::persistent::schema::{Schema, SchemaError, SchemaIterator};
+
+pub trait DatabaseWithScheme {
+    fn put<S: Schema>(&self, key: &S::Key, value: &S::Value) -> Result<(), SchemaError>;
+
+    fn get<S: Schema>(&self, key: &S::Key) -> Result<Option<S::Value>, SchemaError>;
+}
+
+impl DatabaseWithScheme for DB {
+    fn put<S: Schema>(&self, key: &S::Key, value: &S::Value) -> Result<(), SchemaError> {
+        let key = key.encode()?;
+        let value = value.encode()?;
+        let cf_handle = self.get_cf_handle(S::COLUMN_FAMILY_NAME)?;
+
+        self.put_cf_opt(cf_handle, &key, &value, &default_write_options())
+            .map_err(convert_rocksdb_err)
+    }
+
+    fn get<S: Schema>(&self, key: &S::Key) -> Result<Option<S::Value>, SchemaError> {
+        let key = key.encode()?;
+        let cf_handle = self.get_cf_handle(S::COLUMN_FAMILY_NAME)?;
+
+        self.get_cf(cf_handle, &k)
+            .map(|value| S::Value::decode(&value))
+            .transpose()
+    }
+}
+
+fn default_write_options() -> WriteOptions {
+    let mut opts = WriteOptions::new();
+    opts.set_sync(true);
+    opts
+}

--- a/storage/src/persistent/database.rs
+++ b/storage/src/persistent/database.rs
@@ -80,6 +80,6 @@ impl<S: Schema> DatabaseWithSchema<S> for DB {
 
 fn default_write_options() -> WriteOptions {
     let mut opts = WriteOptions::default();
-    opts.set_sync(true);
+    opts.set_sync(false);
     opts
 }

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use rocksdb::{DB, Options};
+use rocksdb::{ColumnFamilyDescriptor, DB, Options};
 
 pub use database::{DatabaseWithSchema, DBError};
 pub use schema::{Codec, Schema, SchemaError};
@@ -11,13 +11,12 @@ pub use schema::{Codec, Schema, SchemaError};
 pub mod schema;
 pub mod database;
 
-pub fn open_db<P, I, N>(path: P, cfs: I) -> Result<DB, DBError>
+pub fn open_db<P, I>(path: P, cfs: I) -> Result<DB, DBError>
 where
     P: AsRef<Path>,
-    I: IntoIterator<Item = N>,
-    N: AsRef<str>,
+    I: IntoIterator<Item = ColumnFamilyDescriptor>,
 {
-    DB::open_cf(&default_db_options(), path, cfs)
+    DB::open_cf_descriptors(&default_db_options(), path, cfs)
         .map_err(DBError::from)
 }
 

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) SimpleStaking and Tezos-RS Contributors
+// SPDX-License-Identifier: MIT
+
+pub mod schema;
+pub mod database;

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -17,11 +17,13 @@ where
     I: IntoIterator<Item = N>,
     N: AsRef<str>,
 {
+    DB::open_cf(&default_db_options(), path, cfs)
+        .map_err(DBError::from)
+}
 
+fn default_db_options() -> Options {
     let mut db_opts = Options::default();
     db_opts.create_missing_column_families(true);
     db_opts.create_if_missing(true);
-
-    DB::open_cf(&db_opts, path, cfs)
-        .map_err(DBError::from)
+    db_opts
 }

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -22,8 +22,6 @@ where
 
 fn default_db_options() -> Options {
     let mut db_opts = Options::default();
-    db_opts.set_max_write_buffer_number(1024);
-    db_opts.set_min_write_buffer_number_to_merge(16);
     db_opts.create_missing_column_families(true);
     db_opts.create_if_missing(true);
     db_opts

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -1,5 +1,27 @@
 // Copyright (c) SimpleStaking and Tezos-RS Contributors
 // SPDX-License-Identifier: MIT
 
+use std::path::Path;
+
+use rocksdb::{DB, Options};
+
+pub use database::{DatabaseWithSchema, DBError};
+pub use schema::{Codec, Schema, SchemaError};
+
 pub mod schema;
 pub mod database;
+
+pub fn open_db<P, I, N>(path: P, cfs: I) -> Result<DB, DBError>
+where
+    P: AsRef<Path>,
+    I: IntoIterator<Item = N>,
+    N: AsRef<str>,
+{
+
+    let mut db_opts = Options::default();
+    db_opts.create_missing_column_families(true);
+    db_opts.create_if_missing(true);
+
+    DB::open_cf(&db_opts, path, cfs)
+        .map_err(DBError::from)
+}

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -22,6 +22,8 @@ where
 
 fn default_db_options() -> Options {
     let mut db_opts = Options::default();
+    db_opts.set_max_write_buffer_number(1024);
+    db_opts.set_min_write_buffer_number_to_merge(16);
     db_opts.create_missing_column_families(true);
     db_opts.create_if_missing(true);
     db_opts

--- a/storage/src/persistent/schema.rs
+++ b/storage/src/persistent/schema.rs
@@ -3,6 +3,7 @@
 
 use failure::Fail;
 use tezos_encoding::hash::HashRef;
+use rocksdb::ColumnFamilyDescriptor;
 
 /// Possible errors for schema
 #[derive(Debug, Fail)]
@@ -25,6 +26,8 @@ pub trait Schema {
     type Key: Codec;
 
     type Value: Codec;
+
+    fn cf_descriptor() -> ColumnFamilyDescriptor;
 }
 
 impl Codec for HashRef {

--- a/storage/src/persistent/schema.rs
+++ b/storage/src/persistent/schema.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use failure::Fail;
+use tezos_encoding::hash::HashRef;
 
 /// Possible errors for schema
 #[derive(Debug, Fail)]
@@ -26,3 +27,12 @@ pub trait Schema {
     type Value: Codec;
 }
 
+impl Codec for HashRef {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+        Ok(HashRef::new(bytes.to_vec()))
+    }
+
+    fn encode(&self) -> Result<Vec<u8>, SchemaError> {
+        Ok(self.get_hash())
+    }
+}

--- a/storage/src/persistent/schema.rs
+++ b/storage/src/persistent/schema.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 use failure::Fail;
-use rocksdb::{ColumnFamily, DBIterator, DB};
-use networking::p2p::binary_message::BinaryMessage;
-use failure::_core::marker::PhantomData;
 
 /// Possible errors for schema
 #[derive(Debug, Fail)]
@@ -18,55 +15,14 @@ pub enum SchemaError {
 pub trait Codec: Sized {
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError>;
 
-    fn encode(&self) -> Result<Vec<[u8]>, SchemaError>;
+    fn encode(&self) -> Result<Vec<u8>, SchemaError>;
 }
 
 pub trait Schema {
-    const COLUMN_FAMILY: &'static str;
+    const COLUMN_FAMILY_NAME: &'static str;
 
     type Key: Codec;
 
     type Value: Codec;
-}
-
-
-mod test {
-    use super::*;
-    use networking::p2p::encoding::prelude::*;
-    use tezos_encoding::hash::{HashRef, Hash};
-
-    struct OperationStorageItem;
-
-    impl Codec for Hash {
-
-        fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-            unimplemented!()
-        }
-
-        fn encode(&self) -> Result<Vec<[u8]>, SchemaError> {
-            unimplemented!()
-        }
-    }
-
-    impl Codec for OperationsForBlocksMessage {
-        fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
-            unimplemented!()
-        }
-
-        fn encode(&self) -> Result<Vec<[u8]>, SchemaError> {
-            unimplemented!()
-        }
-    }
-
-    impl Schema for OperationStorageItem {
-        const COLUMN_FAMILY_NAME: &'static str = "ops_for_blks";
-        type Key = Hash;
-        type Value = OperationsForBlocksMessage;
-    }
-
-
-    fn how_to() {
-
-    }
 }
 

--- a/storage/src/persistent/schema.rs
+++ b/storage/src/persistent/schema.rs
@@ -1,0 +1,72 @@
+// Copyright (c) SimpleStaking and Tezos-RS Contributors
+// SPDX-License-Identifier: MIT
+
+use failure::Fail;
+use rocksdb::{ColumnFamily, DBIterator, DB};
+use networking::p2p::binary_message::BinaryMessage;
+use failure::_core::marker::PhantomData;
+
+/// Possible errors for schema
+#[derive(Debug, Fail)]
+pub enum SchemaError {
+    #[fail(display = "Failed to encode value")]
+    EncodeError,
+    #[fail(display = "Failed to decode value")]
+    DecodeError,
+}
+
+pub trait Codec: Sized {
+    fn decode(bytes: &[u8]) -> Result<Self, SchemaError>;
+
+    fn encode(&self) -> Result<Vec<[u8]>, SchemaError>;
+}
+
+pub trait Schema {
+    const COLUMN_FAMILY: &'static str;
+
+    type Key: Codec;
+
+    type Value: Codec;
+}
+
+
+mod test {
+    use super::*;
+    use networking::p2p::encoding::prelude::*;
+    use tezos_encoding::hash::{HashRef, Hash};
+
+    struct OperationStorageItem;
+
+    impl Codec for Hash {
+
+        fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+            unimplemented!()
+        }
+
+        fn encode(&self) -> Result<Vec<[u8]>, SchemaError> {
+            unimplemented!()
+        }
+    }
+
+    impl Codec for OperationsForBlocksMessage {
+        fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
+            unimplemented!()
+        }
+
+        fn encode(&self) -> Result<Vec<[u8]>, SchemaError> {
+            unimplemented!()
+        }
+    }
+
+    impl Schema for OperationStorageItem {
+        const COLUMN_FAMILY_NAME: &'static str = "ops_for_blks";
+        type Key = Hash;
+        type Value = OperationsForBlocksMessage;
+    }
+
+
+    fn how_to() {
+
+    }
+}
+

--- a/storage/src/persistent/schema.rs
+++ b/storage/src/persistent/schema.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 use failure::Fail;
+use rocksdb::{ColumnFamilyDescriptor, Options};
+
 use tezos_encoding::hash::HashRef;
-use rocksdb::ColumnFamilyDescriptor;
 
 /// Possible errors for schema
 #[derive(Debug, Fail)]
@@ -27,7 +28,9 @@ pub trait Schema {
 
     type Value: Codec;
 
-    fn cf_descriptor() -> ColumnFamilyDescriptor;
+    fn cf_descriptor() -> ColumnFamilyDescriptor {
+        ColumnFamilyDescriptor::new(Self::COLUMN_FAMILY_NAME, Options::default())
+    }
 }
 
 impl Codec for HashRef {

--- a/tezos_encoding/Cargo.toml
+++ b/tezos_encoding/Cargo.toml
@@ -14,7 +14,7 @@ futures-preview = "0.3.0-alpha.18"
 hex = "0.3.2"
 num-bigint = "0.2.2"
 num-traits = "0.2.8"
-serde = { version = "1.0.101", features = ["derive"] }
+serde = { version = "1.0.101", features = ["derive", "rc"] }
 serde_json = "1.0.40"
 # local dependencies
 crypto = { path = "../crypto" }

--- a/tezos_encoding/Cargo.toml
+++ b/tezos_encoding/Cargo.toml
@@ -14,7 +14,7 @@ futures-preview = "0.3.0-alpha.18"
 hex = "0.3.2"
 num-bigint = "0.2.2"
 num-traits = "0.2.8"
-serde = { version = "1.0.101", features = ["derive", "rc"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
 # local dependencies
 crypto = { path = "../crypto" }

--- a/tezos_encoding/Cargo.toml
+++ b/tezos_encoding/Cargo.toml
@@ -14,7 +14,7 @@ futures-preview = "0.3.0-alpha.18"
 hex = "0.3.2"
 num-bigint = "0.2.2"
 num-traits = "0.2.8"
-serde = { version = "1.0.97", features = ["derive"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.40"
 # local dependencies
 crypto = { path = "../crypto" }

--- a/tezos_encoding/src/hash.rs
+++ b/tezos_encoding/src/hash.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 use crypto::base58::{FromBase58Check, FromBase58CheckError, ToBase58Check};
 
 mod prefix_bytes {
@@ -89,7 +91,7 @@ impl HashEncoding {
 }
 
 
-#[derive(Clone, Hash, PartialEq, PartialOrd, Debug, Eq)]
+#[derive(Clone, Serialize, Deserialize, Hash, PartialEq, PartialOrd, Debug, Eq)]
 pub struct HashRef {
     pub hash: Arc<Hash>,
 }

--- a/tezos_encoding/src/hash.rs
+++ b/tezos_encoding/src/hash.rs
@@ -91,7 +91,7 @@ impl HashEncoding {
 
 #[derive(Clone, Hash, PartialEq, PartialOrd, Debug, Eq)]
 pub struct HashRef {
-    hash: Arc<Hash>,
+    pub hash: Arc<Hash>,
 }
 
 impl HashRef {
@@ -107,8 +107,6 @@ impl HashRef {
 pub trait ToHashRef {
     fn to_hash_ref(self) -> HashRef;
 }
-
-
 
 impl<T: AsRef<[u8]>> ToHashRef for T {
     fn to_hash_ref(self) -> HashRef {

--- a/tezos_encoding/src/hash.rs
+++ b/tezos_encoding/src/hash.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 use crypto::base58::{FromBase58Check, FromBase58CheckError, ToBase58Check};
 
 mod prefix_bytes {
@@ -91,7 +89,7 @@ impl HashEncoding {
 }
 
 
-#[derive(Clone, Serialize, Deserialize, Hash, PartialEq, PartialOrd, Debug, Eq)]
+#[derive(Clone, Hash, PartialEq, PartialOrd, Debug, Eq)]
 pub struct HashRef {
     pub hash: Arc<Hash>,
 }


### PR DESCRIPTION
Because the data received during the node bootstrap will take too much memory I have decided to use RocksDB as a storage. This will help to reduce memory footprint significantly while preserving the performance.